### PR TITLE
Add .NET 4 project and solution

### DIFF
--- a/Forecast.io.40.sln
+++ b/Forecast.io.40.sln
@@ -1,0 +1,20 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Forecast.io.40", "forecast.io\Forecast.io.40.csproj", "{505F13DA-0FF3-4B14-8A30-86D8EB95F0AC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{505F13DA-0FF3-4B14-8A30-86D8EB95F0AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{505F13DA-0FF3-4B14-8A30-86D8EB95F0AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{505F13DA-0FF3-4B14-8A30-86D8EB95F0AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{505F13DA-0FF3-4B14-8A30-86D8EB95F0AC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/forecast.io/Forecast.io.40.csproj
+++ b/forecast.io/Forecast.io.40.csproj
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{505F13DA-0FF3-4B14-8A30-86D8EB95F0AC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Forecast.io</RootNamespace>
+    <AssemblyName>Forecast.io</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Entities\CompressedWebClient.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="Entities\Contants.cs" />
+    <Compile Include="Entities\ForecastIORequest.cs" />
+    <Compile Include="Entities\ForecastIOResponse.cs" />
+    <Compile Include="Extensions\Extensions.cs" />
+    <Compile Include="Helpers\RequestHelpers.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>


### PR DESCRIPTION
This will facilitate building a .NET 4 version of the application for NuGet distribution.

i'm never figured out the best way to pack NuGets again multiple versions of .NET. This bit of code is inspired by my (mis)understanding of JSON.NET's NuGet packing process for multiple frameworks.

Is this something you want to add? If so, i can build a nuget packing powershell script for you. If not, i'll just use my own fork of this library until i can upgrade my parent application to .NET 4.5.
