### PR TITLE
Fix default request.Proxy setting

### DIFF
--- a/forecast.io/Entities/CompressedWebClient.cs
+++ b/forecast.io/Entities/CompressedWebClient.cs
@@ -9,6 +9,7 @@ namespace ForecastIO
         {
             var request = base.GetWebRequest(address) as HttpWebRequest;
             if (request == null) return null;
+            request.Proxy = null; //Prevents a possible 10+ sec delay (See http://stackoverflow.com/questions/2519655/httpwebrequest-is-extremely-slow/3603413#3603413)
             request.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
             return request;
         }


### PR DESCRIPTION
Prevents a possible 10+ sec delay (See http://stackoverflow.com/questions/2519655/httpwebrequest-is-extremely-slow/3603413#3603413)
