### PR TITLE
Set webclient encoding to UTF8 - fixes #11

### DIFF
--- a/forecast.io/Entities/ForecastIORequest.cs
+++ b/forecast.io/Entities/ForecastIORequest.cs
@@ -30,6 +30,7 @@ namespace ForecastIO
             string result;
             using (var client = new CompressionEnabledWebClient())
             {
+                client.Encoding = Encoding.UTF8;
                 result = RequestHelpers.FormatResponse(client.DownloadString(url));
                 // Set response values.
                 _apiResponseTime = client.ResponseHeaders["X-Response-Time"];


### PR DESCRIPTION
Just a minor change to the webclient. Setting the encoding explicitly to UTF8 takes care of problem #11, and other encoding issues which may have emerged.
