### PR TITLE
ForecastIORequest is now testable.

### DIFF
--- a/forecast.io/Entities/ForecastIORequest.cs
+++ b/forecast.io/Entities/ForecastIORequest.cs
@@ -6,92 +6,185 @@ using System.Web.Script.Serialization;
 
 namespace ForecastIO
 {
+    /// <summary>
+    /// The forecast IO request.
+    /// </summary>
     public class ForecastIORequest : IForecastIORequest
     {
-        private readonly string _apiKey;
-        private readonly string _latitude;
-        private readonly string _longitude;
-        private readonly string _unit;
-        private readonly string _exclude;
-        private readonly string _extend;
-        private readonly string _time;
-        //
-        private string _apiCallsMade;
-        private string _apiResponseTime;
-        //
-
+        /// <summary>
+        /// The current forecast url.
+        /// </summary>
         private const string CurrentForecastUrl = "https://api.forecast.io/forecast/{0}/{1},{2}?units={3}&extend={4}&exclude={5}";
+
+        /// <summary>
+        /// The period forecast url.
+        /// </summary>
         private const string PeriodForecastUrl = "https://api.forecast.io/forecast/{0}/{1},{2},{3}?units={4}&extend={5}&exclude={6}";
+        
+        /// <summary>
+        /// The API key.
+        /// </summary>
+        private readonly string apiKey;
 
-        public ForecastIOResponse Get()
+        /// <summary>
+        /// The API calls made.
+        /// </summary>
+        private string apiCallsMade;
+
+        /// <summary>
+        /// The API response time.
+        /// </summary>
+        private string apiResponseTime;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ForecastIORequest"/> class.
+        /// </summary>
+        public ForecastIORequest()
         {
-            var url = (_time == null) ? String.Format(CurrentForecastUrl, _apiKey, _latitude, _longitude, _unit, _extend, _exclude) :
-                String.Format(PeriodForecastUrl, _apiKey, _latitude, _longitude, _time, _unit, _extend, _exclude);
+        }
 
-            string result;
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ForecastIORequest"/> class.
+        /// </summary>
+        /// <param name="apiKey">
+        /// The API key.
+        /// </param>
+        public ForecastIORequest(string apiKey)
+        {
+            // ensure args
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                throw new ArgumentNullException("apiKey", "API key must be provided.");
+            }
+
+            // set api key
+            this.apiKey = apiKey;
+        }
+
+        /// <summary>
+        /// Gets the API calls made.
+        /// </summary>
+        public string ApiCallsMade
+        {
+            get
+            {
+                if (this.apiCallsMade != null)
+                {
+                    return this.apiCallsMade;
+                }
+
+                throw new Exception("Cannot retrieve API Calls Made. No calls have been made to the API yet.");
+            }
+        }
+
+        /// <summary>
+        /// Gets the API response time.
+        /// </summary>
+        public string ApiResponseTime
+        {
+            get
+            {
+                if (this.apiResponseTime != null)
+                {
+                    return this.apiResponseTime;
+                }
+
+                throw new Exception("Cannot retrieve API Reponse Time. No calls have been made to the API yet.");
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the forecast for the give latitude, longitude and unit.
+        /// </summary>
+        /// <param name="latitude">
+        /// The latitude.
+        /// </param>
+        /// <param name="longitude">
+        /// The longitude.
+        /// </param>
+        /// <param name="unit">
+        /// The unit (i.e, US).
+        /// </param>
+        /// <param name="extend">
+        /// Extended options.
+        /// </param>
+        /// <param name="exclude">
+        /// All exclusions.
+        /// </param>
+        /// <returns>
+        /// The <see cref="ForecastIOResponse"/>.
+        /// </returns>
+        public ForecastIOResponse Get(
+            float latitude,
+            float longitude,
+            Unit unit,
+            Extend[] extend = null,
+            Exclude[] exclude = null)
+        {
+            return this.Get(latitude, longitude, null, unit);
+        }
+
+        /// <summary>
+        /// Retrieves the forecast for the give latitude, longitude and unit.
+        /// </summary>
+        /// <param name="latitude">
+        /// The latitude.
+        /// </param>
+        /// <param name="longitude">
+        /// The longitude.
+        /// </param>
+        /// <param name="time">
+        /// The time.
+        /// </param>
+        /// <param name="unit">
+        /// The unit (i.e, US).
+        /// </param>
+        /// <param name="extend">
+        /// Extended options.
+        /// </param>
+        /// <param name="exclude">
+        /// All exclusions.
+        /// </param>
+        /// <returns>
+        /// The <see cref="ForecastIOResponse"/>.
+        /// </returns>
+        public ForecastIOResponse Get(
+            float latitude,
+            float longitude,
+            DateTime? time,
+            Unit unit,
+            Extend[] extend = null,
+            Exclude[] exclude = null)
+        {
+            var latitudeOption = latitude.ToString(CultureInfo.InvariantCulture);
+            var longitudeOption = longitude.ToString(CultureInfo.InvariantCulture);
+            var timeOption = time.HasValue ? time.Value.ToUTCString() : string.Empty;
+            var unitOption = Enum.GetName(typeof(Unit), unit);
+            var extendOption = (extend != null) ? RequestHelpers.FormatExtendString(extend) : string.Empty;
+            var excludeOption = (exclude != null) ? RequestHelpers.FormatExcludeString(exclude) : string.Empty;
+
+            // create url
+            var url = string.IsNullOrWhiteSpace(timeOption) ? string.Format(CurrentForecastUrl, this.apiKey, latitudeOption, longitudeOption, unitOption, extendOption, excludeOption) :
+                string.Format(PeriodForecastUrl, this.apiKey, latitudeOption, longitudeOption, timeOption, unitOption, extendOption, excludeOption);
+
+            // placeholder for result
+            var result = default(string);
+
+            // initiate the call to the API
             using (var client = new CompressionEnabledWebClient())
             {
                 client.Encoding = Encoding.UTF8;
                 result = RequestHelpers.FormatResponse(client.DownloadString(url));
+
                 // Set response values.
-                _apiResponseTime = client.ResponseHeaders["X-Response-Time"];
-                _apiCallsMade = client.ResponseHeaders["X-Forecast-API-Calls"];
+                this.apiResponseTime = client.ResponseHeaders["X-Response-Time"];
+                this.apiCallsMade = client.ResponseHeaders["X-Forecast-API-Calls"];
             }
 
             var serializer = new JavaScriptSerializer();
             var dataObject = serializer.Deserialize<ForecastIOResponse>(result);
 
             return dataObject;
-
-        }
-
-        public ForecastIORequest()
-        {
-        }
-
-        public ForecastIORequest(string apiKey, float latF, float longF, Unit unit, Extend[] extend = null, Exclude[] exclude = null)
-        {
-            _apiKey = apiKey;
-            _latitude = latF.ToString(CultureInfo.InvariantCulture);
-            _longitude = longF.ToString(CultureInfo.InvariantCulture);
-            _unit = Enum.GetName(typeof(Unit), unit);
-            _extend = (extend != null) ? RequestHelpers.FormatExtendString(extend) : "";
-            _exclude = (exclude != null) ? RequestHelpers.FormatExcludeString(exclude) : "";
-        }
-
-        public ForecastIORequest(string apiKey, float latF, float longF, DateTime time, Unit unit, Extend[] extend = null, Exclude[] exclude = null)
-        {
-            _apiKey = apiKey;
-            _latitude = latF.ToString(CultureInfo.InvariantCulture);
-            _longitude = longF.ToString(CultureInfo.InvariantCulture);
-            _time = time.ToUTCString();
-            _unit = Enum.GetName(typeof(Unit), unit);
-            _extend = (extend != null) ? RequestHelpers.FormatExtendString(extend) : "";
-            _exclude = (exclude != null) ? RequestHelpers.FormatExcludeString(exclude) : "";
-        }
-
-        public string ApiCallsMade
-        {
-            get
-            {
-                if (_apiCallsMade != null)
-                {
-                    return _apiCallsMade;
-                }
-                throw new Exception("Cannot retrieve API Calls Made. No calls have been made to the API yet.");
-            }
-        }
-
-        public string ApiResponseTime
-        {
-            get
-            {
-                if (_apiResponseTime != null)
-                {
-                    return _apiResponseTime;
-                }
-                throw new Exception("Cannot retrieve API Reponse Time. No calls have been made to the API yet.");
-            }
         }
     }
 }

--- a/forecast.io/Entities/ForecastIORequest.cs
+++ b/forecast.io/Entities/ForecastIORequest.cs
@@ -6,7 +6,7 @@ using System.Web.Script.Serialization;
 
 namespace ForecastIO
 {
-    public class ForecastIORequest
+    public class ForecastIORequest : IForecastIORequest
     {
         private readonly string _apiKey;
         private readonly string _latitude;
@@ -43,6 +43,10 @@ namespace ForecastIO
 
             return dataObject;
 
+        }
+
+        public ForecastIORequest()
+        {
         }
 
         public ForecastIORequest(string apiKey, float latF, float longF, Unit unit, Extend[] extend = null, Exclude[] exclude = null)

--- a/forecast.io/Entities/IForecastIORequest.cs
+++ b/forecast.io/Entities/IForecastIORequest.cs
@@ -1,0 +1,11 @@
+﻿namespace ForecastIO
+{
+    public interface IForecastIORequest
+    {
+        ForecastIOResponse Get();
+
+        string ApiCallsMade { get; }
+
+        string ApiResponseTime { get; }
+    }
+}

--- a/forecast.io/Entities/IForecastIORequest.cs
+++ b/forecast.io/Entities/IForecastIORequest.cs
@@ -1,11 +1,80 @@
-﻿namespace ForecastIO
+namespace ForecastIO
 {
+    using System;
+
+    /// <summary>
+    /// The ForecastIORequest interface.
+    /// </summary>
     public interface IForecastIORequest
     {
-        ForecastIOResponse Get();
+        /// <summary>
+        /// Retrieves the forecast for the give latitude, longitude and unit.
+        /// </summary>
+        /// <param name="latitude">
+        /// The latitude.
+        /// </param>
+        /// <param name="longitude">
+        /// The longitude.
+        /// </param>
+        /// <param name="unit">
+        /// The unit (i.e, US).
+        /// </param>
+        /// <param name="extend">
+        /// Extended options.
+        /// </param>
+        /// <param name="exclude">
+        /// All exclusions.
+        /// </param>
+        /// <returns>
+        /// The <see cref="ForecastIOResponse"/>.
+        /// </returns>
+        ForecastIOResponse Get(
+            float latitude,
+            float longitude,
+            Unit unit,
+            Extend[] extend = null,
+            Exclude[] exclude = null);
 
+        /// <summary>
+        /// Retrieves the forecast for the give latitude, longitude and unit.
+        /// </summary>
+        /// <param name="latitude">
+        /// The latitude.
+        /// </param>
+        /// <param name="longitude">
+        /// The longitude.
+        /// </param>
+        /// <param name="time">
+        /// The time.
+        /// </param>
+        /// <param name="unit">
+        /// The unit (i.e, US).
+        /// </param>
+        /// <param name="extend">
+        /// Extended options.
+        /// </param>
+        /// <param name="exclude">
+        /// All exclusions.
+        /// </param>
+        /// <returns>
+        /// The <see cref="ForecastIOResponse"/>.
+        /// </returns>
+        ForecastIOResponse Get(
+            float latitude,
+            float longitude,
+            DateTime? time,
+            Unit unit,
+            Extend[] extend = null,
+            Exclude[] exclude = null);
+
+        /// <summary>
+        /// Gets the API calls made.
+        /// </summary>
         string ApiCallsMade { get; }
 
+        /// <summary>
+        /// Gets the API response time.
+        /// </summary>
         string ApiResponseTime { get; }
     }
 }

--- a/forecast.io/Forecast.io.40.csproj
+++ b/forecast.io/Forecast.io.40.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Entities\Contants.cs" />
     <Compile Include="Entities\ForecastIORequest.cs" />
     <Compile Include="Entities\ForecastIOResponse.cs" />
+    <Compile Include="Entities\IForecastIORequest.cs" />
     <Compile Include="Extensions\Extensions.cs" />
     <Compile Include="Helpers\RequestHelpers.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
I changed the fundamentals of how the ForecastIORequest works, instead of a class that operates on its fields, the Get methods now ask for the data. I did this because it felt more natural to work that way when you wanted to build a wrapper for your class. By extracting an interface I can now add it to an MVC controller and pass in a mock. This works great for me, and due to the changes, I don't actually expect anyone to accept the pull request as it changes completely how the request worked, but I figured that I should share that option.